### PR TITLE
Updated to version 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,8 @@ After successful installation, open the plugin by going to Extensions > Plugin, 
 - Open the PPD component configuration by going to Components > Pay Per Download > Configuration.
 - On the "Gateway Settings" tab, set "Use PayPal" to NO, "Use Payment Gateway Plugin" to YES.
 
-### Current Constraints
-- Nigerian NGN currency code is not in the PPD component by default. I had to add Currency Code manually to PPD (see how to [here](http://www.ratmilwebsolutions.com/forum/4-payperdownload-support/2545-how-to-add-new-currency.html) ). I had to also add a field for capturing currency code in the payment plugin because of this. I hope I can remove the field in later versions.
+### Constraints
+- (In version 1.0): Nigerian NGN currency code is not in the PPD component by default. I had to add Currency Code manually to PPD (see how to [here](http://www.ratmilwebsolutions.com/forum/4-payperdownload-support/2545-how-to-add-new-currency.html) ). I had to also add a field for capturing currency code in the payment plugin because of this. I hope I can remove the field in later versions.
+
+## Update
+- (In version 1.1): The PayPerDownload plugin version 6.1.0 now factors in a dropdown for you to select your currency. This plugin has been updated to reflect that upgrade (Thanks Olivier and Ratmil!).

--- a/en-GB.plg_payperdownloadplus_paystackpay.ini
+++ b/en-GB.plg_payperdownloadplus_paystackpay.ini
@@ -17,6 +17,3 @@ COM_PAYSTACKPAY_EXTRA_TYPE="Paystack Extra charges type"
 COM_PAYSTACKPAY_EXTRACHARGESDESC="Push the charges as a percentage of the total, or as a fixed amount"
 COM_PAYSTACKPAY_EXTRA_VALUE="Paystack Extra charges value"
 COM_PAYSTACKPAY_EXTRACHARGE_VALUEDESC="The value of the extra charges"
-
-COM_PAYSTACKPAY_CURR="Currency Code"
-COM_PAYSTACKPAY_CURR_DESC="You can change to the three-letter currency code you want to receive payments in e.g. USD, CAD, GBP. Check https://thefactfile.org/countries-currencies-symbols/ for other examples. NOTE: PLEASE only change the value if you have activated International Payments in your PayStack Account."

--- a/paystackpay.php
+++ b/paystackpay.php
@@ -23,7 +23,7 @@ class joomla_pp_paystack_plugin_tracker {
         $this->plugin_name = $plugin;
         $this->public_key = $pk;
     }
-   
+
     function log_transaction_success($trx_ref){
         //send reference to logger along with plugin name and public key
         $url = "https://plugin-tracker.paystackintegrations.com/log/charge_success";
@@ -37,7 +37,7 @@ class joomla_pp_paystack_plugin_tracker {
         curl_setopt($ch,CURLOPT_URL, $url);
         curl_setopt($ch,CURLOPT_POST, true);
         curl_setopt($ch,CURLOPT_POSTFIELDS, $fields_string);
-        curl_setopt($ch,CURLOPT_RETURNTRANSFER, true); 
+        curl_setopt($ch,CURLOPT_RETURNTRANSFER, true);
         //execute post
         $result = curl_exec($ch);
         //  echo $result;
@@ -80,7 +80,7 @@ class plgPayperDownloadPlusPaystackPay extends JPlugin
 				if($resource)
 				{
 					$damount = $resource->resource_price;
-					$currency = $pmntinfo->currency; //$currency = $resource->resource_price_currency;
+					$currency = $resource->resource_price_currency; //$currency = $pmntinfo->currency;
 					$item_id = $resource->resource_license_id;
 					$name = $resource->resource_name;
 					$download_id = $resource->download_id;
@@ -94,7 +94,7 @@ class plgPayperDownloadPlusPaystackPay extends JPlugin
 				else
 				{
 					$damount = $license->price;
-					$currency = $pmntinfo->currency; //$currency = $license->currency_code;
+					$currency = $license->currency_code; //$currency = $pmntinfo->currency;
 					$item_id = $license->license_id;
 					$name = $license->license_name;
 					$description = $license->description;
@@ -231,7 +231,7 @@ class plgPayperDownloadPlusPaystackPay extends JPlugin
 						//-------------
 
 
-						
+
 						// Update order status - From pending to complete
 						$amount = $amount;// / 100.0;
 						$payed = true;
@@ -405,7 +405,7 @@ public function getPaystackPaymentInfo()
 	$pddpinfo->ps_extratype = $this->params->get('paystack_extra_type');
 	$pddpinfo->ps_extraval = $this->params->get('paystack_extra_charges_value');
 
-	$pddpinfo->currency = $this->params['paystack_currcode'];
+	//$pddpinfo->currency = $this->params['paystack_currcode'];
 	return $pddpinfo;
 }
 

--- a/paystackpay.xml
+++ b/paystackpay.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension version="1.6" method="upgrade" type="plugin" group="payperdownloadplus">
 	<name>PayperDownloadPlus - PaystackPay</name>
-	<version>1.0</version>
+	<version>1.1</version>
 	<creationDate>Aug 2019</creationDate>
 	<author>Daydah Adeniyi</author>
 	<authorUrl>www.jibitech.com</authorUrl>
@@ -48,8 +48,8 @@
 				</field>
 				<field type="spacer" />
 				<field type="text" name="paystack_extra_charges_value" description="COM_PAYSTACKPAY_EXTRACHARGE_VALUEDESC" default="1.5" label="COM_PAYSTACKPAY_EXTRA_VALUE" size="30"/>
-				<field type="spacer" />
-				<field type="text" name="paystack_currcode" description="COM_PAYSTACKPAY_CURR_DESC" default="NGN" label="COM_PAYSTACKPAY_CURR" size="3" />
+		<!--		<field type="spacer" />
+				<field type="text" name="paystack_currcode" description="COM_PAYSTACKPAY_CURR_DESC" default="NGN" label="COM_PAYSTACKPAY_CURR" size="3" /> -->
 			</fieldset>
 		</fields>
 	</config>


### PR DESCRIPTION
- Removed the currency workarounds.
- Is compatible with PayPerDownload version 6.1.0 upwards.